### PR TITLE
기본 JPA 설정 및 데이터베이스 통합

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,11 +27,16 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-devtools'
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'  // 버전 업데이트
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'junit:junit:4.13.2'
+
+
 }
 
 tasks.named('test') {

--- a/spy.properties
+++ b/spy.properties
@@ -1,0 +1,3 @@
+appender=com.p6spy.engine.spy.appender.Slf4JLogger
+logMessageFormat=com.p6spy.engine.spy.appender.CustomLineFormat
+customLogMessageFormat=%(currentTime)|%(executionTime)|%(category)|connection%(connectionId)|%(sql)

--- a/src/main/java/jpabook/jpashop/HelloController.java
+++ b/src/main/java/jpabook/jpashop/HelloController.java
@@ -1,0 +1,14 @@
+package jpabook.jpashop;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HelloController {
+    @GetMapping("hello")
+    public String hello(Model model) {
+        model.addAttribute("data", "hello!!");
+        return "hello";
+    }
+}

--- a/src/main/java/jpabook/jpashop/Member.java
+++ b/src/main/java/jpabook/jpashop/Member.java
@@ -1,0 +1,17 @@
+package jpabook.jpashop;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class Member {
+
+    @Id @GeneratedValue
+    private Long id;
+    private String userName;
+}

--- a/src/main/java/jpabook/jpashop/MemberRepository.java
+++ b/src/main/java/jpabook/jpashop/MemberRepository.java
@@ -1,0 +1,20 @@
+package jpabook.jpashop;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MemberRepository {
+    @PersistenceContext
+    private EntityManager em;
+
+    public Long save(Member member) {
+        em.persist(member);
+        return member.getId();
+    }
+
+    public Member find(Long id) {
+        return em.find(Member.class, id);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=jpashop

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/jpashop
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+#        show_sql: true
+        format_sql: true
+logging.level:
+  org.hibernate.SQL: debug
+  org.hibernate.orm.jdbc.bind: trace  

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Hello</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head>
+<body>
+Hello
+<a href="/hello">hello</a>
+</body>
+</html>

--- a/src/main/resources/templates/hello.html
+++ b/src/main/resources/templates/hello.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Hello</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head>
+<body>
+<p th:text="'안녕하세요.' + ${data}" >안녕하세요. 손님</p>
+</body>
+</html>

--- a/src/test/java/jpabook/jpashop/MemberRepositoryTest.java
+++ b/src/test/java/jpabook/jpashop/MemberRepositoryTest.java
@@ -1,0 +1,40 @@
+package jpabook.jpashop;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class MemberRepositoryTest {
+
+    @Autowired MemberRepository memberRepository;
+
+    @Test
+    @Transactional
+    @Rollback(value = false)
+    public void testMember() throws Exception {
+        // given
+        Member member = new Member();
+        member.setUserName("memberA");
+
+        // when
+        Long savedId = memberRepository.save(member);
+        Member findMember = memberRepository.find(savedId);
+
+        // then
+        Assertions.assertThat(findMember.getId()).isEqualTo(member.getId());
+        Assertions.assertThat(findMember.getUserName()).isEqualTo(member.getUserName());
+        Assertions.assertThat(findMember).isEqualTo(member);
+
+    }
+
+
+}


### PR DESCRIPTION
이 pr은 프로젝트에 JPA 기본 설정을 추가하고, H2 데이터베이스를 통한 통합을 구현한다. SQL 로깅 활성화와 기본 엔티티 관리를 위한 리포지토리를 포함한다.

- JPA 및 데이터베이스 관련 의존성 추가
- SQL 로깅을 위한 P6Spy 설정
- Member 엔티티와 MemberRepository 구현
- HelloController와 간단한 웹 페이지 템플릿 추가
- 애플리케이션 설정을 YAML로 구성
- MemberRepositoryTest를 통한 JPA 설정 검증