### PR TITLE
변경 감지와 병합

### DIFF
--- a/src/main/java/jpabook/jpashop/controller/ItemController.java
+++ b/src/main/java/jpabook/jpashop/controller/ItemController.java
@@ -62,17 +62,10 @@ public class ItemController {
     }
 
     @PostMapping("items/{itemId}/edit")
-    public String updateItem(@PathVariable("itemId") String itemId, @ModelAttribute("form") BookForm form){
+    public String updateItem(@PathVariable("itemId") Long itemId, @ModelAttribute("form") BookForm form){
 
-        Book book = new Book();
-        book.setId(form.getId());
-        book.setName(form.getName());
-        book.setPrice(form.getPrice());
-        book.setStockQuantity(form.getStockQuantity());
-        book.setAuthor(form.getAuthor());
-        book.setIsbn(form.getIsbn());
+        itemService.updateItem(itemId, form.getName(), form.getPrice(), form.getStockQuantity());
 
-        itemService.saveItem(book);
         return "redirect:/items";
     }
 }

--- a/src/main/java/jpabook/jpashop/service/ItemService.java
+++ b/src/main/java/jpabook/jpashop/service/ItemService.java
@@ -1,5 +1,6 @@
 package jpabook.jpashop.service;
 
+import jpabook.jpashop.domain.item.Book;
 import jpabook.jpashop.domain.item.Item;
 import jpabook.jpashop.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,15 @@ public class ItemService {
         itemRepository.save(item);
     }
 
+    // 변경 감지 기능 사용
+    @Transactional
+    public void updateItem(Long itemId, String name, int price, int stockQuantity) {
+        Item findItem = itemRepository.findOne(itemId);
+        findItem.setName(name);
+        findItem.setPrice(price);
+        findItem.setStockQuantity(stockQuantity);
+    }
+
     public List<Item> findItems() {
         return itemRepository.findAll();
     }
@@ -28,3 +38,5 @@ public class ItemService {
         return itemRepository.findOne(itemId);
     }
 }
+
+


### PR DESCRIPTION
### 변경 사항
- ItemController의 기존 상품 수정 로직에서 Book 객체를 수동으로 생성해 수정하던 방식을 영속성 컨텍스트의 변경 감지 기능으로 대체
- 변경 감지를 활용해 수정할 상품의 영속 상태 엔티티를 조회하고, 필요한 필드만 수정할 수 있도록 개선
- ItemService에 updateItem 메서드를 추가하여, 변경 감지로 데이터베이스에 필요한 업데이트만 반영하도록 최적화

### 주요 수정 내용
- ItemController: 병합 방식에서 변경 감지 방식으로 수정, 불필요한 Book 객체 수동 생성 제거
- ItemService: 영속성 컨텍스트에서 관리되는 엔티티를 변경 감지로 수정하는 updateItem 메서드 추가

### 테스트
- 상품 수정 후, 데이터베이스에 변경 사항이 정확히 반영되는지 테스트
- 변경 감지가 정상적으로 동작해 수정된 필드만 업데이트되는지 확인
